### PR TITLE
Change request to allow more characters in select

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,7 @@ Sorting is done using a `sort` Query Parameter. Sort order can be either ascendi
 
 The syntax is:
 
-    sort="<attribute>+/-|<attribute>+/-|..."
-
-and is equivalent to: `sort="<attribute>::+/-|<attribute>::+/-|..."`.
+    sort="<attribute>::+/-|<attribute>::+/-|..."
 
 #### Simple Example
 
@@ -82,7 +80,7 @@ sorts accounts by ascending balance.
 
 #### Sorting on two properties
 
-    https://banking.services.sample-bank.dk/accounts?select=balance|lastUpdate-
+    https://banking.services.sample-bank.dk/accounts?select=balance|lastUpdate::-
 
 sorts accounts by ascending balance and descending lastUpdate.
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ selects accounts having a balance between 100 and 1000 (both inclusive).
 
 selects the two accounts having account numbers "123456789" and "234567890".
 
+#### Selecting with wildcards
+
+    https://banking.services.sample-bank.dk/accounts?select="name::savings*|name::*loan*"
+
+selects accounts having a name starting with "savings" or containing "loan"
+
 ### Sorting API Capability
 
 Sorting is done using a `sort` Query Parameter. Sort order can be either ascending (default) or descending.

--- a/src/main/java/io/openapitools/api/capabilities/Sanitizer.java
+++ b/src/main/java/io/openapitools/api/capabilities/Sanitizer.java
@@ -1,5 +1,7 @@
 package io.openapitools.api.capabilities;
 
+import java.util.regex.Pattern;
+
 /**
  * API input sanitizer in a rudimental version.
  */
@@ -11,11 +13,20 @@ public final class Sanitizer {
     }
 
     /**
+     * Joined and escaped string of suspicious content.
+     *
+     * @return String.
+     */
+    static String regexQuotedSuspiciousContent() {
+        return Pattern.quote(String.join("", SUSPICIOUS_CONTENT));
+    }
+
+    /**
      * A simple sanitizer that needs to be extended and elaborated to cope with injections and
      * other things that pose as threats to the services and the data they contain and maintain.
      *
-     * @param input an input string received from a non-trustworthy source (in reality every source)
-     * @param allowSpaces should the string be stripped for spaces or allow these to stay
+     * @param input        an input string received from a non-trustworthy source (in reality every source)
+     * @param allowSpaces  should the string be stripped for spaces or allow these to stay
      * @param allowNumbers can the input contain numbers or not
      * @return a sanitized string or an empty string if the sanitation failed for some reason.
      */
@@ -40,7 +51,8 @@ public final class Sanitizer {
 
     /**
      * A default version of the santizer used from the local capabilities and thus
-     * @param input an input string received from a non-trustworthy source (in reality every source)
+     *
+     * @param input       an input string received from a non-trustworthy source (in reality every source)
      * @param allowSpaces should the string be stripped for spaces or allow these to stay
      * @return a sanitized string or an empty string if the sanitation failed for some reason
      */

--- a/src/main/java/io/openapitools/api/capabilities/Select.java
+++ b/src/main/java/io/openapitools/api/capabilities/Select.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
  * <p>
  * Indicated by using an API Query Parameter called {@code select}.
  * <p>
- * The syntax is: {@code select="<attribute>::<value>|<atribute>::<value>|..."}
+ * The syntax is: {@code select="<attribute>::<value>|<attribute>::<value>|..."}
  * <p>
  * Example:
  * <p>
@@ -21,24 +21,17 @@ import java.util.regex.Pattern;
  * key for an account.
  */
 public final class Select {
-    private static final Pattern REGEX =
-        Pattern.compile("^(([a-z][a-zA-Z_0-9]*)::([a-zA-Z_0-9]+)(-|\\+)?)?((\\|[a-z][a-zA-Z_0-9]*)?::([a-zA-Z_0-9]+)(-|\\+)?)*");
+    private static final String PAIR = "([a-z][a-zA-Z_0-9]*)::([^|" + Sanitizer.regexQuotedSuspiciousContent() + "]+)";
+    private static final Pattern REGEX = Pattern.compile("^" + PAIR + "(\\|" + PAIR + ")*");
+
     private static final CapabilityParser<Select> PARSER = new CapabilityParser<>(REGEX, Select::parseToken);
 
-    private String attribute = "";
-    private String value = "";
+    private String attribute;
+    private String value;
 
     private Select(String attribute, String value) {
         this.attribute = attribute;
         this.value = value;
-    }
-
-    public String getAttribute() {
-        return attribute;
-    }
-
-    public String getValue() {
-        return value;
     }
 
     /**
@@ -50,8 +43,6 @@ public final class Select {
      * {@code "attribute::value|anotherAttribute::thatValue|yetAnotherAttribute::thisValue"}
      * and so on, it may also take the form {@code "attribute::value|attribute::thatValue|attribute::thisValue"}
      * <p>
-     * The regexp is:
-     * {@code ^(([a-z][a-zA-Z_0-9]*)::([a-zA-Z_0-9]+)(-|\\+)?)?((\\|[a-z][a-zA-Z_0-9]*)?::([a-zA-Z_0-9]+)(-|\\+)?)*}
      *
      * @param select the select Query Parameter
      * @return a set of attribute(s) and value(s) used for selecting candidates for the response
@@ -62,13 +53,20 @@ public final class Select {
 
     private static Optional<Select> parseToken(String token) {
         String attribute = token.substring(0, token.indexOf(':'));
-        return Optional.of(new Select(attribute, getValuefrom(token)));        
+        return Optional.of(new Select(attribute, getValueFrom(token)));
     }
 
-    private static String getValuefrom(String selection) {
+    private static String getValueFrom(String selection) {
         int startsAt = selection.indexOf("::") + "::".length();
         int endsAt = !selection.contains("|") ? selection.length() : selection.indexOf('|');
         return selection.substring(startsAt, endsAt);
     }
 
+    public String getAttribute() {
+        return attribute;
+    }
+
+    public String getValue() {
+        return value;
+    }
 }

--- a/src/test/java/io/openapitools/api/capabilities/SelectTest.java
+++ b/src/test/java/io/openapitools/api/capabilities/SelectTest.java
@@ -1,28 +1,28 @@
 package io.openapitools.api.capabilities;
 
+import org.junit.Test;
+
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
 
 public class SelectTest {
 
 
     @Test
-    public void testNoSelection(){
+    public void testNoSelection() {
         List<Select> selections = Select.getSelections(null);
         assertEquals(0, selections.size());
     }
 
     @Test
-    public void testEmptySelection(){
+    public void testEmptySelection() {
         List<Select> selections = Select.getSelections("");
         assertEquals(0, selections.size());
     }
 
     @Test
-    public void testWrongSelection(){
+    public void testWrongSelection() {
         List<Select> selections = Select.getSelections("::");
         assertEquals(0, selections.size());
         selections = Select.getSelections("|");
@@ -30,7 +30,7 @@ public class SelectTest {
     }
 
     @Test
-    public void testIllegalSelection(){
+    public void testIllegalSelection() {
         List<Select> selections = Select.getSelections("?::4");
         assertEquals(0, selections.size());
         selections = Select.getSelections("3::4");
@@ -44,33 +44,40 @@ public class SelectTest {
     }
 
     @Test
-    public void testSimpleSelection(){
+    public void testSimpleSelection() {
         List<Select> selections = Select.getSelections("u::4");
         assertEquals(1, selections.size());
         selections = Select.getSelections("attribute::value");
         assertEquals(1, selections.size());
         selections = Select.getSelections("a::value");
         assertEquals(1, selections.size());
+        selections = Select.getSelections("attribute:: value");
+        assertEquals(1, selections.size());
+        selections = Select.getSelections("attribute:: value ");
+        assertEquals(1, selections.size());
+        selections = Select.getSelections("attribute::value ");
+        assertEquals(1, selections.size());
     }
 
     @Test
-    public void testSelectionWithWhiteSpaceAttribute(){
+    public void testAdditionalSpecific() {
+        assertEquals(" S p a c e s ", Select.getSelections("attribute:: S p a c e s ").get(0).getValue());
+        assertEquals("(parenthesis)", Select.getSelections("attribute::(parenthesis)").get(0).getValue());
+        assertEquals("forward/slash", Select.getSelections("attribute::forward/slash").get(0).getValue());
+    }
+
+    @Test
+    public void testSelectionWithWhiteSpaceAttribute() {
         List<Select> selections = Select.getSelections("attribute ::value");
         assertEquals(0, selections.size());
         selections = Select.getSelections("attribute ::value");
         assertEquals(0, selections.size());
         selections = Select.getSelections(" attribute::value");
         assertEquals(0, selections.size());
-        selections = Select.getSelections("attribute:: value");
-        assertEquals(0, selections.size());
-        selections = Select.getSelections("attribute:: value ");
-        assertEquals(0, selections.size());
-        selections = Select.getSelections("attribute::value ");
-        assertEquals(0, selections.size());
     }
 
     @Test
-    public void testSelectionWithSuspiciousCharacters(){
+    public void testSelectionWithSuspiciousCharacters() {
         List<Select> selections = Select.getSelections("attribute or '1' = '1::value");
         assertEquals(0, selections.size());
         selections = Select.getSelections("attribute or '1' = '1::value");
@@ -90,7 +97,7 @@ public class SelectTest {
     }
 
     @Test
-    public void testSelectionCriteria(){
+    public void testSelectionCriteria() {
         List<Select> selections = Select.getSelections("attribute::value|otherAttribute::otherValue");
         assertEquals(2, selections.size());
         boolean attributeValueObserved = false;
@@ -112,7 +119,7 @@ public class SelectTest {
     }
 
     @Test
-    public void testSelectionHavingMultipleCriteria(){
+    public void testSelectionHavingMultipleCriteria() {
         List<Select> selections = Select.getSelections("attribute::value|otherAttribute::otherValue");
         assertEquals(2, selections.size());
         boolean attributeValueObserved = false;
@@ -157,7 +164,7 @@ public class SelectTest {
     }
 
     @Test
-    public void testIllegalSelections(){
+    public void testIllegalSelections() {
         List<Select> selections = Select.getSelections("?::4|a::b");
         assertEquals(0, selections.size());
         selections = Select.getSelections("?::4|a::b");
@@ -167,5 +174,4 @@ public class SelectTest {
         selections = Select.getSelections("v::g|f::j|u::iio|3::4");
         assertEquals(0, selections.size());
     }
-
 }

--- a/src/test/java/io/openapitools/api/capabilities/SelectTest.java
+++ b/src/test/java/io/openapitools/api/capabilities/SelectTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class SelectTest {
 
@@ -173,5 +174,14 @@ public class SelectTest {
         assertEquals(0, selections.size());
         selections = Select.getSelections("v::g|f::j|u::iio|3::4");
         assertEquals(0, selections.size());
+    }
+    
+    @Test
+    public void testWildcards() {
+        List<Select> selections = Select.getSelections("name::*loan|name::savings*");
+        assertEquals(2, selections.size());
+        for (Select sel : selections) {
+            assertTrue(sel.getValue().equals("*loan") || sel.getValue().equals("savings*"));
+        }
     }
 }


### PR DESCRIPTION
Changes:
- Changed select logic to allow more characters in 'value' part
- Added wildcards to select syntax, to accommodate searching by partial strings
- Updated readme to reflect actual implementation (alternatively the implementation should be changed to allow `<attribute>+/-`)
